### PR TITLE
adding 1h cache to all /api requests

### DIFF
--- a/firstrussian/urls.py
+++ b/firstrussian/urls.py
@@ -20,13 +20,21 @@ schema_view = get_schema_view(
 )
 
 urlpatterns = [
-    # apis
+    # apis in root
     path("", include(events.urls.router.urls)),
     path("", include(sermons.urls.router.urls)),
     path("", include(people.urls.router.urls)),
     path("", include(media.urls.router.urls)),
     path("", include(files.urls.router.urls)),
     path("", include(thoughts.urls.router.urls)),
+    # apis
+    path("api/", include(events.urls.router.urls)),
+    path("api/", include(sermons.urls.router.urls)),
+    path("api/", include(people.urls.router.urls)),
+    path("api/", include(media.urls.router.urls)),
+    path("api/", include(files.urls.router.urls)),
+    path("api/", include(thoughts.urls.router.urls)),
+    # redirect swagger
     path("", RedirectView.as_view(pattern_name="schema-swagger-ui"), name="api-root"),
     # api docs
     re_path(

--- a/nginx/files/sites-enabled/https.conf
+++ b/nginx/files/sites-enabled/https.conf
@@ -36,6 +36,12 @@ server {
         try_files            $uri @proxy;
     }
 
+    location /api {
+        alias                /data/static/;
+        try_files            $uri @proxy;
+        expires              1h;
+    }
+
     location @proxy {
         proxy_pass           "http://app:8000";
         include              proxy_params.conf;


### PR DESCRIPTION
fixes #14

@SKaistrenko this is backwards compatible but will allow to cache all api responses easily in nginx